### PR TITLE
Send/receive only when requested

### DIFF
--- a/doom-wasm.nix
+++ b/doom-wasm.nix
@@ -1,16 +1,17 @@
-{
-  lib,
-  autoconf,
-  automake,
-  gnumake,
-  python3,
-  pkg-config,
-  buildEmscriptenPackage,
-  libpng,
-  libsamplerate,
-  unar,
-  unzip,
-}: let
+{ lib
+, autoconf
+, automake
+, gnumake
+, python3
+, pkg-config
+, buildEmscriptenPackage
+, libpng
+, libsamplerate
+, unar
+, unzip
+,
+}:
+let
   ports = {
     ogg = {
       url = "https://github.com/emscripten-ports/ogg/archive/version_1.zip";
@@ -34,58 +35,56 @@
     };
   };
 in
-  buildEmscriptenPackage {
-    name = "doom-wasm";
+buildEmscriptenPackage {
+  name = "doom-wasm";
 
-    # EMCC_DEBUG = "2";
+  # EMCC_DEBUG = "2";
 
-    nativeBuildInputs = [
-      pkg-config
-      python3
-      unar
-      unzip
-    ];
+  nativeBuildInputs = [
+    pkg-config
+    python3
+    unar
+    unzip
+  ];
 
-    buildInputs = [
-      autoconf
-      automake
-      gnumake
-      libpng
-      libsamplerate
-    ];
+  buildInputs = [
+    autoconf
+    automake
+    gnumake
+  ];
 
-    src = ./.;
+  src = ./.;
 
-    configurePhase = ''
-      export EM_CACHE=$TMPDIR/.emscriptencache
+  configurePhase = ''
+    export EM_CACHE=$TMPDIR/.emscriptencache
 
-      mkdir -p $EM_CACHE/ports
+    mkdir -p $EM_CACHE/ports
 
-      pushd $EM_CACHE/ports
-      ${lib.concatStrings (builtins.attrValues (builtins.mapAttrs (name: value: ''
-          mkdir ${name}
-          pushd ${name}
-          echo ${value.url} > .emscripten_url
-          unar ${builtins.fetchurl value}
-          popd
-        '')
-        ports))}
-      popd
-      emconfigure autoreconf -fiv
-      ac_cv_exeext=".html" emconfigure ./configure --host=none-none-none || cat config.log
-    '';
+    pushd $EM_CACHE/ports
+    ${lib.concatStrings (builtins.attrValues (builtins.mapAttrs (name: value: ''
+        mkdir ${name}
+        pushd ${name}
+        echo ${value.url} > .emscripten_url
+        unar ${builtins.fetchurl value}
+        popd
+      '')
+      ports))}
+    popd
+    emconfigure autoreconf -fiv
+    ac_cv_exeext=".html" emconfigure ./configure --host=none-none-none || cat config.log
+  '';
 
-    buildPhase = ''
-      emmake make
-    '';
+  buildPhase = ''
+    emmake make
+  '';
 
-    installPhase = ''
-      mkdir -p $out
-      cp src/websockets-doom.html $out
-      cp src/websockets-doom.js $out
-      cp src/websockets-doom.wasm $out
-      cp src/websockets-doom.wasm.map $out
-    '';
+  installPhase = ''
+    mkdir -p $out
+    cp src/websockets-doom.html $out
+    cp src/websockets-doom.js $out
+    cp src/websockets-doom.wasm $out
+    cp src/websockets-doom.wasm.map $out
+  '';
 
-    checkPhase = ":";
-  }
+  checkPhase = ":";
+}

--- a/flake.nix
+++ b/flake.nix
@@ -39,8 +39,6 @@
               SDL2
               SDL2_mixer
               SDL2_net
-              libpng.dev
-              libsamplerate
             ];
           };
       });

--- a/src/doom/g_game.c
+++ b/src/doom/g_game.c
@@ -808,6 +808,11 @@ void G_Ticker(void)
             if(M_CheckParm("-hydra-recv") > 0) {
                 hydra_recv(cmd);
                 printf("hydra recv: forwardmove=%i\n", cmd->forwardmove);
+
+                // Do not play demo if we are only receiving
+                if(M_CheckParm("-hydra-send") == 0) {
+                    demoplayback = false;
+                }
             }
 
             if (demoplayback) G_ReadDemoTiccmd(cmd);

--- a/src/doom/g_game.c
+++ b/src/doom/g_game.c
@@ -915,8 +915,9 @@ void G_Ticker(void)
                 killcount = players[i].killcount;
                 mo = &players[i].mo;
 
-                printf("hydra send: forwardmove=%i buttons=%i health=%i, floorz=%i, momx=%i, momy=%i, momz=%i, z=%i, angle=%i, x=%i, y=%i\n",
+                printf("hydra send: forwardmove=%i sidemove=%i buttons=%i health=%i, floorz=%i, momx=%i, momy=%i, momz=%i, z=%i, angle=%i, x=%i, y=%i\n",
                     cmd->forwardmove,
+                    cmd->sidemove,
                     cmd->buttons,
                     mo->health,
                     mo->floorz,

--- a/src/doom/g_game.c
+++ b/src/doom/g_game.c
@@ -802,6 +802,14 @@ void G_Ticker(void)
 
             memcpy(cmd, &netcmds[i], sizeof(ticcmd_t));
 
+            // Receive input from Hydra (the network)
+            // XXX: This indicates that we could also integrate hydra via the
+            // netcmds and d_net module system (like the net_websockets module)
+            if(M_CheckParm("-hydra-recv") > 0) {
+                hydra_recv(cmd);
+                printf("hydra recv: forwardmove=%i\n", cmd->forwardmove);
+            }
+
             if (demoplayback) G_ReadDemoTiccmd(cmd);
             if (demorecording) G_WriteDemoTiccmd(cmd);
 
@@ -893,25 +901,28 @@ void G_Ticker(void)
         break;
     }
 
-    // Send updated state to chain
-    for (i = 0; i < MAXPLAYERS; i++) {
-        if (playeringame[i]) {
-            player_state = players[i].playerstate;
-            killcount = players[i].killcount;
-            mo = &players[i].mo;
+    // Send updated state to Hydra
+    // FIXME: only send our own state
+    if(M_CheckParm("-hydra-send") > 0) {
+        for (i = 0; i < MAXPLAYERS; i++) {
+            if (playeringame[i]) {
+                player_state = players[i].playerstate;
+                killcount = players[i].killcount;
+                mo = &players[i].mo;
 
-            printf("hydra send: forwardmove=%i buttons=%i health=%i, floorz=%i, momx=%i, momy=%i, momz=%i, z=%i, angle=%i, x=%i, y=%i\n",
-                cmd->forwardmove,
-                cmd->buttons,
-                mo->health,
-                mo->floorz,
-                mo->momx,
-                mo->momy,
-                mo->momz,
-                mo->angle,
-                mo->x,
-                mo->y);
-            hydra_send(cmd, player_state, killcount, mo->health, mo->floorz, mo->momx, mo->momy, mo->momz, mo->z, mo->angle, gamestate);
+                printf("hydra send: forwardmove=%i buttons=%i health=%i, floorz=%i, momx=%i, momy=%i, momz=%i, z=%i, angle=%i, x=%i, y=%i\n",
+                    cmd->forwardmove,
+                    cmd->buttons,
+                    mo->health,
+                    mo->floorz,
+                    mo->momx,
+                    mo->momy,
+                    mo->momz,
+                    mo->angle,
+                    mo->x,
+                    mo->y);
+                hydra_send(cmd, player_state, killcount, mo->health, mo->floorz, mo->momx, mo->momy, mo->momz, mo->z, mo->angle, gamestate);
+            }
         }
     }
 }
@@ -1702,9 +1713,6 @@ void G_InitNew(skill_t skill, int episode, int map)
 
 void G_ReadDemoTiccmd(ticcmd_t *cmd)
 {
-    hydra_recv(cmd);
-    printf("hydra recv: forwardmove=%i\n", cmd->forwardmove);
-
     if (*demo_p == DEMOMARKER) {
         // end of demo data stream
         G_CheckDemoStatus();
@@ -2010,7 +2018,6 @@ void G_DoPlayDemo(void)
 
     usergame = false;
     demoplayback = true;
-    printf("hydra: connect and read from head\n");
 }
 
 //

--- a/src/doom/hydra.h
+++ b/src/doom/hydra.h
@@ -13,7 +13,7 @@
 // hydra_send(cmd, player_state, killcount, mo->health, mo->floorz, mo->momx, mo->momy, mo->momz, mo->z, mo->angle, gamestate);
 
 EM_ASYNC_JS(void, hydra_send, (ticcmd_t *cmd, playerstate_t playerstate, int killcount, int health, int floorz, int momx, int momy, int momz, int z, int angle, gamestate_t gamestate), {
-  console.log("glue out", "forwardmove", HEAPU8[cmd]);
+  console.log("hydra_send", "forwardmove", HEAPU8[cmd]);
   await hydraSend({
     forwardMove: HEAPU8[cmd]
   },
@@ -38,13 +38,14 @@ EM_ASYNC_JS(void, hydra_send, (ticcmd_t *cmd, playerstate_t playerstate, int kil
 // TODO: calling c from javascript proved itself as hard because the
 // EXPORTED_FUNCTIONS option would not work?
 
-EM_JS(void, hydra_recv, (ticcmd_t *cmd), {
-  const res = hydraRecv();
-  console.log("glue in", res);
+EM_ASYNC_JS(void, hydra_recv, (ticcmd_t *cmd), {
+  const res = await hydraRecv();
+  console.log("hydra_recv", res);
   if (res == null) {
      return;
   }
   HEAPU8[cmd] = res.forwardMove;
+  // FIXME: integrate more ticcmd_t fields
 });
 
 #endif

--- a/src/doom/hydra.h
+++ b/src/doom/hydra.h
@@ -13,9 +13,9 @@
 // hydra_send(cmd, player_state, killcount, mo->health, mo->floorz, mo->momx, mo->momy, mo->momz, mo->z, mo->angle, gamestate);
 
 EM_ASYNC_JS(void, hydra_send, (ticcmd_t *cmd, playerstate_t playerstate, int killcount, int health, int floorz, int momx, int momy, int momz, int z, int angle, gamestate_t gamestate), {
-  console.log("hydra_send", "forwardmove", HEAPU8[cmd]);
   await hydraSend({
-    forwardMove: HEAPU8[cmd]
+    forwardMove: HEAP8[cmd],
+    sideMove: HEAP8[cmd+1],
   },
   {
     mapObject: {
@@ -44,7 +44,8 @@ EM_ASYNC_JS(void, hydra_recv, (ticcmd_t *cmd), {
   if (res == null) {
      return;
   }
-  HEAPU8[cmd] = res.forwardMove;
+  HEAP8[cmd] = res.forwardMove;
+  HEAP8[cmd+1] = res.sideMove;
   // FIXME: integrate more ticcmd_t fields
 });
 


### PR DESCRIPTION
* Only send data into Hydra if `-hydra-send` is set
* Only receive data from Hydra if `-hydra-recv` is set
* Don't playback demo if only `-hydra-recv` is set
* Some fixes on the manual `doom-wasm` build